### PR TITLE
Each run of the JSON Schema directive should reset include_used and collapse_used

### DIFF
--- a/sphinxcontrib/jsonschema.py
+++ b/sphinxcontrib/jsonschema.py
@@ -52,9 +52,11 @@ class JSONSchemaDirective(Directive):
         include = self.options.get('include')
         if include:
             self.include = include.split(',')
+            self.include_used = set()
         collapse = self.options.get('collapse')
         if collapse:
             self.collapse = collapse.split(',')
+            self.collapse_used = set()
 
         env = self.state.document.settings.env
         try:

--- a/tests/test_jsonschema.py
+++ b/tests/test_jsonschema.py
@@ -213,7 +213,7 @@ class TestJsonSchema(unittest.TestCase):
         }"""
         schema = JSONSchema.loads(data)
         self.assertEqual(schema.validations,
-                         ['It must be equal to one of the elements ' +
+                         ['It must be equal to one of the elements '
                           'in ["string", {"type": "object", "maxProperties": 3}, null, 42]'])
 
 # Validation for any instance type


### PR DESCRIPTION
I don't have merge privileges, but this error means that there is no warning for `documents` here: https://github.com/open-contracting/infrastructure/blame/6445305077666721f1fac676fc74a0b5f5bbcc9d/docs/projects/reference.md#L28

cc @duncandewhurst 