### PR TITLE
typo: full_title is an attribute not a method

### DIFF
--- a/sphinxcontrib/jsonschema.py
+++ b/sphinxcontrib/jsonschema.py
@@ -504,7 +504,7 @@ class Object(JSONData):
         if isinstance(self.parent, Array):
             return self.parent.full_title
         else:
-            return super().full_title()
+            return super().full_title
 
 
 def setup(app):


### PR DESCRIPTION
Required to produce metadata tables for the 360Giving docs.